### PR TITLE
Bundle OSS licenses

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,6 @@ if !git.modified_files.include?("CHANGELOG.md") && github.branch_for_base == "ma
   fail("Please include a CHANGELOG entry.")
 end
 
-
 if !git.modified_files.include?("CHANGELOG.md") && github.branch_for_base == "dev"
   warn("You might want to include a CHANGELOG entry.")
 end
@@ -14,10 +13,6 @@ end
 
 if git.commits.any? { |c| c.message.include?('fixup!') || c.message.include?('squash!') }
   fail('This PR contains commits marked as squash or fixup. Please perform an interactive rebase to apply the changes.')
-end
-
-if git.diff.include?("@objc dynamic var")
-  warn 'Possible Database Migration needed!'
 end
 
 swiftlint.config_file = '.swiftlint.yml'

--- a/Dangerfile
+++ b/Dangerfile
@@ -15,5 +15,12 @@ if git.commits.any? { |c| c.message.include?('fixup!') || c.message.include?('sq
   fail('This PR contains commits marked as squash or fixup. Please perform an interactive rebase to apply the changes.')
 end
 
+podfile_updated = git.modified_files.include?("Podfile")
+no_license_updated = git.modified_files.grep(/Settings.bundle/).empty?
+
+if podfile_updated && no_license_updated
+  warn("The `Podfile` was updated, but there were no changes in `Settings.bundle`. Did you forget to generate OSS license plists?")
+end
+
 swiftlint.config_file = '.swiftlint.yml'
 swiftlint.lint_files

--- a/LunchGuy.xcodeproj/project.pbxproj
+++ b/LunchGuy.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D25127211FA4D157008449E1 /* GoogleMapsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25127201FA4D157008449E1 /* GoogleMapsApp.swift */; };
 		D25127231FA4D1C8008449E1 /* AppleMapsApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25127221FA4D1C8008449E1 /* AppleMapsApp.swift */; };
 		D25127251FA4D1DD008449E1 /* YelpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D25127241FA4D1DD008449E1 /* YelpApp.swift */; };
+		D25127271FA65A88008449E1 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D25127261FA65A88008449E1 /* Settings.bundle */; };
 		D289BB2B1F9F992A00BD126B /* MealCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D289BB2A1F9F992A00BD126B /* MealCategory.swift */; };
 		D2AE95611FA28DDF00763608 /* RestaurantLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AE95601FA28DDF00763608 /* RestaurantLocationProvider.swift */; };
 		D2AE95631FA28E5100763608 /* RestaurantStaticLocationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AE95621FA28E5100763608 /* RestaurantStaticLocationProvider.swift */; };
@@ -60,6 +61,7 @@
 		D25127201FA4D157008449E1 /* GoogleMapsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleMapsApp.swift; sourceTree = "<group>"; };
 		D25127221FA4D1C8008449E1 /* AppleMapsApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMapsApp.swift; sourceTree = "<group>"; };
 		D25127241FA4D1DD008449E1 /* YelpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YelpApp.swift; sourceTree = "<group>"; };
+		D25127261FA65A88008449E1 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		D289BB2A1F9F992A00BD126B /* MealCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealCategory.swift; sourceTree = "<group>"; };
 		D2AE95601FA28DDF00763608 /* RestaurantLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantLocationProvider.swift; sourceTree = "<group>"; };
 		D2AE95621FA28E5100763608 /* RestaurantStaticLocationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantStaticLocationProvider.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 		3525C0C11CF3BA7F002114A6 = {
 			isa = PBXGroup;
 			children = (
+				D25127261FA65A88008449E1 /* Settings.bundle */,
 				3525C0CC1CF3BA7F002114A6 /* LunchGuy */,
 				3525C0CB1CF3BA7F002114A6 /* Products */,
 				B60B3C31A36A598ACFF21781 /* Pods */,
@@ -258,6 +261,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3525C0D51CF3BA7F002114A6 /* Assets.xcassets in Resources */,
+				D25127271FA65A88008449E1 /* Settings.bundle in Resources */,
 				3520D8A81F89AEF50025610B /* LaunchScreen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/LunchGuy.xcodeproj/project.pbxproj
+++ b/LunchGuy.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 46;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		D2C9364E1FA67AFC00A4C9E0 /* OSS Licenses */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = D2C936511FA67AFC00A4C9E0 /* Build configuration list for PBXAggregateTarget "OSS Licenses" */;
+			buildPhases = (
+				D2C936521FA67B0F00A4C9E0 /* Generate OSS Licenses plist */,
+			);
+			dependencies = (
+			);
+			name = "OSS Licenses";
+			productName = "OSS Licenses";
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		351CFA781CF3D96F00D4146A /* RestaurantTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351CFA771CF3D96F00D4146A /* RestaurantTableViewController.swift */; };
 		351CFA7A1CF3DD9E00D4146A /* MenuTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 351CFA791CF3DD9E00D4146A /* MenuTableViewController.swift */; };
@@ -235,6 +249,10 @@
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Manual;
 					};
+					D2C9364E1FA67AFC00A4C9E0 = {
+						CreatedOnToolsVersion = 9.0.1;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 3525C0C51CF3BA7F002114A6 /* Build configuration list for PBXProject "LunchGuy" */;
@@ -251,6 +269,7 @@
 			projectRoot = "";
 			targets = (
 				3525C0C91CF3BA7F002114A6 /* LunchGuy */,
+				D2C9364E1FA67AFC00A4C9E0 /* OSS Licenses */,
 			);
 		};
 /* End PBXProject section */
@@ -347,6 +366,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-LunchGuy/Pods-LunchGuy-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		D2C936521FA67B0F00A4C9E0 /* Generate OSS Licenses plist */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate OSS Licenses plist";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which license-plist >/dev/null; then\n    license-plist --add-version-numbers --suppress-opening-directory --output-path Settings.bundle\nelse\n    echo \"error: license-plist not installed, download fromhttps://github.com/mono0926/LicensePlist\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -529,6 +562,22 @@
 			};
 			name = Release;
 		};
+		D2C9364F1FA67AFC00A4C9E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		D2C936501FA67AFC00A4C9E0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -546,6 +595,15 @@
 			buildConfigurations = (
 				3525C0F31CF3BA7F002114A6 /* Debug */,
 				3525C0F41CF3BA7F002114A6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D2C936511FA67AFC00A4C9E0 /* Build configuration list for PBXAggregateTarget "OSS Licenses" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D2C9364F1FA67AFC00A4C9E0 /* Debug */,
+				D2C936501FA67AFC00A4C9E0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>StringsTable</key>
+	<string>Root</string>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+			<key>Title</key>
+			<string>Acknowledgements</string>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
+++ b/Settings.bundle/com.mono0926.LicensePlist.latest_result.txt
@@ -1,0 +1,12 @@
+name: Alamofire, nameSpecified: 
+body: Copyright (c) 2014-2…
+
+name: Crashlytics, nameSpecified: 
+body: Fabric: Copyright 20…
+
+name: Fabric, nameSpecified: 
+body: Fabric: Copyright 20…
+
+add-version-numbers: true
+
+LicensePlist Version: 1.7.0

--- a/Settings.bundle/com.mono0926.LicensePlist.plist
+++ b/Settings.bundle/com.mono0926.LicensePlist.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist/Alamofire</string>
+			<key>Title</key>
+			<string>Alamofire (4.5.1)</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist/Crashlytics</string>
+			<key>Title</key>
+			<string>Crashlytics (3.8.6)</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
+			<string>com.mono0926.LicensePlist/Fabric</string>
+			<key>Title</key>
+			<string>Fabric (1.6.13)</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Settings.bundle/com.mono0926.LicensePlist/Alamofire.plist
+++ b/Settings.bundle/com.mono0926.LicensePlist/Alamofire.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright (c) 2014-2017 Alamofire Software Foundation (http://alamofire.org/)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Settings.bundle/com.mono0926.LicensePlist/Crashlytics.plist
+++ b/Settings.bundle/com.mono0926.LicensePlist/Crashlytics.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>Fabric: Copyright 2017 Google, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Fabric Software and Services Agreement located at https://fabric.io/terms. Crashlytics Kit: Copyright 2017 Crashlytics, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Crashlytics Terms of Service located at http://try.crashlytics.com/terms/terms-of-service.pdf and the Crashlytics Privacy Policy located at http://try.crashlytics.com/terms/privacy-policy.pdf. OSS: http://get.fabric.io/terms/opensource.txt</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Settings.bundle/com.mono0926.LicensePlist/Fabric.plist
+++ b/Settings.bundle/com.mono0926.LicensePlist/Fabric.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>Fabric: Copyright 2017 Google, Inc. All Rights Reserved. Use of this software is subject to the terms and conditions of the Fabric Software and Services Agreement located at https://fabric.io/terms. OSS: http://get.fabric.io/terms/opensource.txt</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Settings.bundle/cs.lproj/Root.strings
+++ b/Settings.bundle/cs.lproj/Root.strings
@@ -1,0 +1,2 @@
+
+"Acknowledgements" = "Licence";


### PR DESCRIPTION
This PR adds OSS licenses into iOS Settings app. With this, LunchGuy finally comply to licenses included in its dependencies and fixes #4.

The license plist files are autogenerated using [LicensePlist](https://github.com/mono0926/LicensePlist) tool which needs to be installed using homebrew explicitly. The Xcode project now also includes aggregated target which runs `LicensePlist` in background. If the tool is not installed, the target build fails.

I also included action for Danger, which warns whenever the `Podfile` was updated, but the license plists remained unmodified.